### PR TITLE
Fix warnings from `shellcheck`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ cleaning/little_dir
 cleaning/big_dir
 cleaning/cleaned_big_dir
 cleaning/cleaned_little_dir
+cleaning/cleaned_big_dir.tgz
+cleaning/cleaned_little_dir.tgz

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# Project files
+
 cleaned_big_dir.tgz
 cleaned_little_dir.tgz
 cleaning/little_dir
@@ -6,3 +8,79 @@ cleaning/cleaned_big_dir
 cleaning/cleaned_little_dir
 cleaning/cleaned_big_dir.tgz
 cleaning/cleaned_little_dir.tgz
+
+
+# Created by https://www.gitignore.io/api/vim,emacs
+# Edit at https://www.gitignore.io/?templates=vim,emacs
+
+### Emacs ###
+# -*- mode: gitignore; -*-
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
+# Org-mode
+.org-id-locations
+*_archive
+
+# flymake-mode
+*_flymake.*
+
+# eshell files
+/eshell/history
+/eshell/lastdir
+
+# elpa packages
+/elpa/
+
+# reftex files
+*.rel
+
+# AUCTeX auto folder
+/auto/
+
+# cask packages
+.cask/
+dist/
+
+# Flycheck
+flycheck_*.el
+
+# server auth directory
+/server/
+
+# projectiles files
+.projectile
+
+# directory configuration
+.dir-locals.el
+
+# network security
+/network-security.data
+
+
+### Vim ###
+# Swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~
+
+# End of https://www.gitignore.io/api/vim,emacs

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ up. So make a bit of an effort, but know when to stop.
 Before you start writing scripts, you’ll need get a copy of this repository
 to work on. This is a two step process:
 
-* First follow the canvas link (which you've alredy done) to create **your copy** of the repository on github classroom.
+* First follow the Canvas link (which you've already done) to create
+  **your copy** of the repository on GitHub Classroom.
 * Then _clone_ **your copy** to the machine you're working on
 
 If you're working in pairs or larger groups only _one_ of you needs to create

--- a/README.md
+++ b/README.md
@@ -52,22 +52,43 @@ up. So make a bit of an effort, but know when to stop.
 Before you start writing scripts, you’ll need get a copy of this repository
 to work on. This is a two step process:
 
-* First follow the canvas link (which you've alredy done) to create **your copy** of the repository on github classrom.
-* Then _clone_ **your fork** to the machine you're working on
+* First follow the canvas link (which you've alredy done) to create **your copy** of the repository on github classroom.
+* Then _clone_ **your copy** to the machine you're working on
 
-If you're working in pairs or larger groups only _one_ of you needs to fork
-the repository, but that person then needs to add everyone else as collaborators on the project, and then everyone will need to clone the project to their machine to work on it.
+If you're working in pairs or larger groups only _one_ of you needs to create
+your group's copy in GitHub Classroom, but everyone else will need to join
+that team in GitHub Classroom so they have access to their team's project.
+Also note that if Pat checks out the project on the first day of lab, and then
+later Chris is logged in when you sit down to work on it again, Chris will
+need to check out the project. It's also crucial that everyone commit their
+work (perhaps to a branch) at the end of each work session so that it will
+accessible to everyone in the team.
 
 You’ll “turn in” your work simply by having it committed to the
 repository. We’ll check it out from there to run and grade it.
 We'll obviously need to be able to find your repository to grade it,
-so make sure to submit the URL of your forked repository
+so make sure to submit the URL of your repository
 using whatever technique is indicated by your instructor.
 
 Be certain to **commit often**, and **trade places at the keyboard
 often**. At a minimum you should probably trade every time you solve
 a specific problem that comes out of the test script. You should probably
 consider committing that often as well.
+
+## :warning: Write clean code
+
+Part of the rubric on this is readability, and shell scripts are notoriously
+difficult read. So remember all the nice habits that you've learned, like
+using good variable names and commenting non-obvious instructions.
+
+You should also run the `shellcheck` command on your shell scripts, e.g.,
+
+```bash
+    shellcheck big_clean.sh
+```
+
+and heed
+(or at least ask questions about) any warnings that it throws your way.
 
 ---
 
@@ -105,16 +126,20 @@ For this you should write a bash script called `extract_and_compile.sh` that:
     -   The first is a number that will be used as an argument when you call the C program that you'll be compiling in a bit.
     -   The second is the name of a directory that you should do extract the files into and compile the program.
 -   Extracts the contents of the tar archive `NthPrime.tgz` into the
-    specified directory. This is a compressed tar file (indicated by
-    the `gz`, for `gzip`, in the file extension),
-    so you’ll need to uncompress and then extract; the `tar` command can
-    do both things in one step. You might find the `man` pages
-    for `tar`. This should create a directory `NthPrime` in your scratch
-    directory; that `NthPrime` directory should contain several `*.c` and
-    `*.h` files that can be compiled to create an executable.
+    specified directory.
+    - This is a compressed tar file (indicated by
+      the `gz`, for `gzip`, in the file extension),
+      so you’ll need to uncompress and then extract; the `tar` command can
+      do both things in one step.
+    - You will almost certainly find the `man` pages
+      for `tar` useful.
+    - This extraction should create a directory `NthPrime` in your scratch
+      directory; that `NthPrime` directory should contain several `*.c` and
+      `*.h` files that can be compiled to create an executable.
 -   Goes into the `NthPrime` directory that the `tar` extraction created.
--   Compiles the C program that gets extracted, generating an executable
+-   Compiles the C program that was extracted, generating an executable
     called `NthPrime` (still in the `NthPrime` directory in your specified temporary directory).
+    - See below for notes on how to compile a C program with the `gcc` compiler.
 -   Call the resulting executable (`NthPrime`). `NthPrime` requires a single
     number as a command line argument; you should pass it the first of the two
     command line arguments your script received.
@@ -162,14 +187,14 @@ the `mkdir` call first). You would want to empty the contents of the scratch
 directory before calling your script a second time, or you won't be able to
 tell what was left over from the first call. You probably want to delete
 `/tmp/frogs` (or whatever you called it) when you're done just as a politness
-so you don't clutter up `/tmp/` unnecessarily.
+so you don't clutter up `/tmp` unnecessarily.
 
 ### Some notes on compiling a C program
 
-The C compiler in the lab is `gcc`.
+The C compiler in the lab is the Gnu C Compiler: `gcc`.
 
 There are two `.c` files in this program, both of which will need to be
-compiled and linked. You can do this in a single line (handing gcc both
+compiled and linked for form an executable. You can do this in a single line (handing gcc both
 `.c` files) or you can compile them separately and then link them.
 
 You can tell `gcc` what you want the executable called, or you can take
@@ -186,7 +211,8 @@ line argument.
 
 ### :warning: Some non-obvious assumptions that the test script makes:
 
-The tests assume that the `.tgz` version of the tar archive will be in the specified directory
+The tests require that the `.tgz` version of the tar archive will still
+be in the specified directory
 when you’re done. This means that if you first `gunzip` and then, in a
 separate step, untar, the test is likely to fail since you’ll end up
 with a `.tar` file instead of a `.tgz` file. _So you should use the appropriate `tar` flags that uncompress and untar in a single step._
@@ -351,7 +377,8 @@ the test isn’t being passed go back and re-read the directions
 
 # What to turn in
 
-You'll "turn this in" by committing your work to your fork of this starter
+You'll "turn this in" by committing your work to your GitHub Classroom
+copy of  the
 project. You should also submit the URL of your repository in whatever way
 indicated by your instructor. Remember to make sure you've completed each
 of the assigned tasks:

--- a/cleaning/tests.bats
+++ b/cleaning/tests.bats
@@ -10,12 +10,12 @@ num_big_remaining_files=792
 
 # Create a temporary scratch directory for the shell script to work in.
 setup() {
-  BATS_TMPDIR=`mktemp --directory`
+  BATS_TMPDIR=$(mktemp --directory)
 }
 
 # Remove the temporary scratch directory to clean up after ourselves.
 teardown() {
-  rm -rf $BATS_TMPDIR
+  rm -rf "$BATS_TMPDIR"
 }
 
 # If this test fails, your script file doesn't exist, or there's
@@ -32,7 +32,7 @@ teardown() {
 # If this test fails, your script either didn't run at all, or it
 # generated some sort of error when it ran.
 @test "big_clean.sh runs successfully" {
-  run ./big_clean.sh $little.tgz $BATS_TMPDIR
+  run ./big_clean.sh $little.tgz "$BATS_TMPDIR"
   [ "$status" -eq 0 ]
 }
 
@@ -41,12 +41,12 @@ teardown() {
 # having trouble debugging this, you might find it useful to call your
 # script directly from the command line and see where it extracted the files.
 @test "big_clean.sh extracts the 'tar' archive contents" {
-  run ./big_clean.sh $little.tgz $BATS_TMPDIR
-  [ -d $BATS_TMPDIR/$little ]
+  run ./big_clean.sh $little.tgz "$BATS_TMPDIR"
+  [ -d "$BATS_TMPDIR"/$little ]
   # This just checks that a few of the files are there.
-  [ -f $BATS_TMPDIR/$little/file_6 ]
-  [ -f $BATS_TMPDIR/$little/file_12 ]
-  [ -f $BATS_TMPDIR/$little/file_18 ]
+  [ -f "$BATS_TMPDIR"/$little/file_6 ]
+  [ -f "$BATS_TMPDIR"/$little/file_12 ]
+  [ -f "$BATS_TMPDIR"/$little/file_18 ]
 }
 
 # If this test fails, you either moved or renamed the compressed `tar` archive.
@@ -54,23 +54,23 @@ teardown() {
 # archive, and then used `tar xf` to extract the contents in a separate step.
 # That would leave the archive as `NthPrime.tar` instead of `NthPrime.tgz`.
 @test "big_clean.sh doesn't remove or rename the compressed 'tar' archive" {
-  run ./big_clean.sh $little.tgz $BATS_TMPDIR
+  run ./big_clean.sh $little.tgz "$BATS_TMPDIR"
   [ -f "$little.tgz" ]
 }
 
 @test "big_clean.sh creates new 'cleaned_little_dir.tgz' archive" {
-  run ./big_clean.sh $little.tgz $BATS_TMPDIR
+  run ./big_clean.sh $little.tgz "$BATS_TMPDIR"
   [ -f "cleaned_$little.tgz" ]
 }
 
 @test "The new archive has the right number of files in it" {
-  ./big_clean.sh $little.tgz $BATS_TMPDIR
+  ./big_clean.sh $little.tgz "$BATS_TMPDIR"
   run bash -c "tar -ztf cleaned_$little.tgz | grep '/f' | wc -l"
   [ "$output" -eq $num_little_remaining_files ]
 }
 
 @test "The new archive has (some) of the right files in it" {
-  ./big_clean.sh $little.tgz $BATS_TMPDIR
+  ./big_clean.sh $little.tgz "$BATS_TMPDIR"
   run bash -c "tar -ztf cleaned_$little.tgz | grep '/f' | sort"
   [ "${lines[0]}" == "little_dir/file_1" ]
   [ "${lines[1]}" == "little_dir/file_10" ]
@@ -78,7 +78,7 @@ teardown() {
 }
 
 @test "big_clean.sh returns the right number of files on the big archive" {
-  run ./big_clean.sh $big.tgz $BATS_TMPDIR
+  run ./big_clean.sh $big.tgz "$BATS_TMPDIR"
   run bash -c "tar -ztf cleaned_$big.tgz | grep '/f' | wc -l"
   [ "$output" -eq $num_big_remaining_files ]
 }

--- a/compiling/tests.bats
+++ b/compiling/tests.bats
@@ -4,12 +4,12 @@ dist=NthPrime
 
 # Create a temporary scratch directory for the shell script to work in.
 setup() {
-  BATS_TMPDIR=`mktemp --directory`
+  BATS_TMPDIR=$(mktemp --directory)
 }
 
 # Remove the temporary scratch directory to clean up after ourselves.
 teardown() {
-  rm -rf $BATS_TMPDIR
+  rm -rf "$BATS_TMPDIR"
 }
 
 # If this test fails, your script file doesn't exist, or there's
@@ -26,7 +26,7 @@ teardown() {
 # If this test fails, your script either didn't run at all, or it
 # generated some sort of error when it ran.
 @test "extract_and_compile.sh runs successfully" {
-  run ./extract_and_compile.sh 5 $BATS_TMPDIR
+  run ./extract_and_compile.sh 5 "$BATS_TMPDIR"
   [ "$status" -eq 0 ]
 }
 
@@ -35,11 +35,11 @@ teardown() {
 # having trouble debugging this, you might find it useful to call your
 # script directly from the command line and see where it extracted the files.
 @test "extract_and_compile.sh extracts the 'tar' archive contents" {
-  run ./extract_and_compile.sh 5 $BATS_TMPDIR
-  [ -d $BATS_TMPDIR/$dist ]
-  [ -f $BATS_TMPDIR/$dist/main.c ]
-  [ -f $BATS_TMPDIR/$dist/nth_prime.c ]
-  [ -f $BATS_TMPDIR/$dist/nth_prime.h ]
+  run ./extract_and_compile.sh 5 "$BATS_TMPDIR"
+  [ -d "$BATS_TMPDIR"/$dist ]
+  [ -f "$BATS_TMPDIR"/$dist/main.c ]
+  [ -f "$BATS_TMPDIR"/$dist/nth_prime.c ]
+  [ -f "$BATS_TMPDIR"/$dist/nth_prime.h ]
 }
 
 # If this test fails, you either moved or renamed the compressed `tar` archive.
@@ -47,7 +47,7 @@ teardown() {
 # archive, and then used `tar xf` to extract the contents in a separate step.
 # That would leave the archive as `NthPrime.tar` instead of `NthPrime.tgz`.
 @test "extract_and_compile.sh doesn't remove or rename the compressed 'tar' archive" {
-  run ./extract_and_compile.sh 5 $BATS_TMPDIR
+  run ./extract_and_compile.sh 5 "$BATS_TMPDIR"
   [ -f "NthPrime.tgz" ]
 }
 
@@ -55,15 +55,15 @@ teardown() {
 # didn't give it the right name. I'd run your script "by hand" and go look in
 # your scratch directory to see what's there.
 @test "extract_and_compile.sh compiles the source" {
-  run ./extract_and_compile.sh 5 $BATS_TMPDIR
-  [ -x $BATS_TMPDIR/$dist/NthPrime ]
+  run ./extract_and_compile.sh 5 "$BATS_TMPDIR"
+  [ -x "$BATS_TMPDIR"/$dist/NthPrime ]
 }
 
 # If this fails you either didn't call the compiled program, or you didn't give
 # it the right command line argument. I'd run your script "by hand" and see
 # what output it generates.
 @test "extract_and_compile.sh computes the correct 5th prime" {
-  run ./extract_and_compile.sh 5 $BATS_TMPDIR
+  run ./extract_and_compile.sh 5 "$BATS_TMPDIR"
   [ "$output" == "Prime 5 = 11." ]
 }
 
@@ -71,6 +71,6 @@ teardown() {
 # it the right command line argument. I'd run your script "by hand" and see
 # what output it generates.
 @test "extract_and_compile.sh computes the correct 103rd prime" {
-  run ./extract_and_compile.sh 103 $BATS_TMPDIR
+  run ./extract_and_compile.sh 103 "$BATS_TMPDIR"
   [ "$output" == "Prime 103 = 563." ]
 }


### PR DESCRIPTION
This fixes all the warnings from `shellcheck` on the two `bats` test files. All the changes were quoting issues except for two instances of using `$(...)` instead of backticks.